### PR TITLE
Add binder badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/multi-template-matching/MultiTemplateMatching-Python/fix-requirements?filepath=tutorials)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/multi-template-matching/MultiTemplateMatching-Python/master?filepath=tutorials)
 
 # Multi-Template-Matching
 Multi-Template-Matching is a package to perform object-recognition in images using one or several smaller template images.  

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-﻿# Multi-Template-Matching
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/multi-template-matching/MultiTemplateMatching-Python/fix-requirements?filepath=tutorials)
+
+# Multi-Template-Matching
 Multi-Template-Matching is a package to perform object-recognition in images using one or several smaller template images.  
 The template and images should have the same bitdepth (8,16,32-bit) and number of channels (single/Grayscale or RGB).  
 The main function `MTM.matchTemplates` returns the best predicted locations provided either a score_threshold and/or the expected number of objects in the image.  

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Multi-Template-Matching==1.5.0
+Multi-Template-Matching==1.5.1
 numpy==1.16.4
 opencv-python-headless==4.1.0.25
 scikit-image==0.15.0


### PR DESCRIPTION
This PR add a binder badge to the README and fixes a version in `requirements.txt`, since `Multi-Template-Matching` version `1.5.0` is not available via pip, but `1.5.1` is.

To test the binder functionality, you can run binder from this PR's branch on my fork:

[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/imagejan/MultiTemplateMatching-Python/fix-requirements?filepath=tutorials)